### PR TITLE
Correctly set kernellocal for elilo

### DIFF
--- a/setupgrubfornfsinstall
+++ b/setupgrubfornfsinstall
@@ -2202,7 +2202,7 @@ else # regular setup with bootloader
 	$echo mkdir -p "$imagedir"
 	if [ "$bootloader" = 'elilo' ]; then
 		initrdlocal="$imagedir/initrd-`shellfriendly "$dist"`"
-		initrdlocal="$imagedir/linux-`shellfriendly "$dist"`"
+		kernellocal="$imagedir/linux-`shellfriendly "$dist"`"
 	else
 		initrdlocal="$imagedir/initrd"
 		kernellocal="$imagedir/linux"


### PR DESCRIPTION
When working with elilo, initrdlocal was set twice because of this fetch_kernel fails to download the kernel:

```
+ curl -L --progress-bar -f -o '' http://servername//install//SLES12-SP1/CD1/boot/x86_64/loader/linux
Warning: Failed to create the file
                                                                           0.0%
curl: (23) Failed writing body (0 != 1203)
```
